### PR TITLE
chrono.setInterval doesn't respect actual interval times because the logi

### DIFF
--- a/chronos.js
+++ b/chronos.js
@@ -102,7 +102,7 @@ window["chronos"] = (function () {
     // returns how many milliseconds are left till the next time it should be
     // run.
     function decrementTimeTillNext (task) {
-        return task.next -= (+new Date()) - task.lastTimeRan;
+        return task.next = task.timeout - ((+new Date()) - task.lastTimeRan);
     }
 
     // Return true if the task repeats multiple times, false if it is a task to


### PR DESCRIPTION
chrono.setInterval doesn't respect actual interval times because the logic of next -= now - lastTimeRan is reducing the next (which keeps getting smaller) by the elapsed time (which keeps getting larger); eg a 1000ms interval repeats every 300ms. Instead we need to set next to relative to the timeout (which is fixed).
