### PR TITLE
Dergistration of a task while run fixed

### DIFF
--- a/chronos.js
+++ b/chronos.js
@@ -145,10 +145,12 @@ window["chronos"] = (function () {
                 if ( tasks[tasksToRun[i]]
                      && decrementTimeTillNext(tasks[tasksToRun[i]]) < INTERVAL / 2 ) {
                     runTask(tasks[tasksToRun[i]]);
-                    if ( taskRepeats(tasks[tasksToRun[i]]) ) {
-                        resetTimeTillNext(tasks[tasksToRun[i]]);
-                    } else {
-                        delete tasks[tasksToRun[i]];
+                    if ( tasks[tasksToRun[i]] ) {
+                      if ( taskRepeats(tasks[tasksToRun[i]]) ) {
+                          resetTimeTillNext(tasks[tasksToRun[i]]);
+                      } else {
+                          delete tasks[tasksToRun[i]];
+                      }
                     }
                 }
             }


### PR DESCRIPTION
If runTask executes a task and the task 
deregisters itself an exception is thrown:  deregistration deleted the
'tasks[tasksToRun[i]]' entry. So after runTask now 'if ( tasks[tasksToRun[i]] )' is performed a second time.
